### PR TITLE
Use vh-check to fix viewport issue on iOS Safari

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,8 +6,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta
-      name="description"
-      content="Web site created using create-react-app"
+      name="Stimulus Checker"
+      content="Calculate the amount of your expected stimulus paycheck. "
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <!--
@@ -28,6 +28,13 @@
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
+    <script src="https://unpkg.com/vh-check/dist/vh-check.min.js"></script>
+    <script>
+      (function () {
+        // Checks for compatibility with vh (which is not supported by iOS Safari)
+        var test = vhCheck();
+      }());
+    </script>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/src/ChildrenSection.css
+++ b/src/ChildrenSection.css
@@ -72,6 +72,7 @@
 
 .children-section-container {
   height: 100vh;
+  height: calc(100vh - var(--vh-offset, 0px));
   
   display: grid;
   grid-gap: 20px;

--- a/src/FilingStatusSection.css
+++ b/src/FilingStatusSection.css
@@ -89,6 +89,7 @@ button {
 
 .marriage-status-section-container {
   height: 100vh;
+  height: calc(100vh - var(--vh-offset, 0px));
   
   display: grid;
   grid-gap: 20px;

--- a/src/IncomeSection.css
+++ b/src/IncomeSection.css
@@ -69,6 +69,7 @@
 
 .income-section-container {
   height: 100vh;
+  height: calc(100vh - var(--vh-offset, 0px));
   
   display: grid;
   grid-gap: 20px;

--- a/src/TaxYearSection.css
+++ b/src/TaxYearSection.css
@@ -73,6 +73,7 @@
 
 .tax-year-section-container {
   height: 100vh;
+  height: calc(100vh - var(--vh-offset, 0px));
   
   display: grid;
   grid-gap: 20px;


### PR DESCRIPTION
This PR brings in the [vh-check](https://github.com/Hiswe/vh-check) library to check whether or not a user's browser supports the `vh` CSS property. If it cannot, it uses this height calcluation: `height: calc(100vh - var(--vh-offset, 0px));`